### PR TITLE
[IMPROVED] Category request acceptance, change, replacement

### DIFF
--- a/Eventy/src/main/java/org/example/eventy/solutions/repositories/SolutionRepository.java
+++ b/Eventy/src/main/java/org/example/eventy/solutions/repositories/SolutionRepository.java
@@ -1,11 +1,14 @@
 package org.example.eventy.solutions.repositories;
 
+import org.example.eventy.solutions.models.Category;
 import org.example.eventy.solutions.models.Solution;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -21,6 +24,13 @@ public interface SolutionRepository extends JpaRepository<Solution, Long> {
 
     @Query("SELECT COUNT(s) FROM Solution s WHERE s.provider.id = :providerId")
     long countByProviderId(@Param("providerId") Long providerId);
+
+    @Modifying
+    @Transactional
+    @Query("UPDATE Solution s SET s.category = :newCategory WHERE s.category = :oldCategory")
+    int updateCategoryForAllSolutions(@Param("oldCategory") Category oldCategory, @Param("newCategory") Category newCategory);
+
+    List<Solution> findByCategory(Category category);
 
     @Query("SELECT s FROM Solution s WHERE s.id IN " +
             "(SELECT us.id FROM User u JOIN u.favoriteSolutions us WHERE u.id = :userId)" +

--- a/Eventy/src/main/java/org/example/eventy/solutions/services/SolutionCategoryService.java
+++ b/Eventy/src/main/java/org/example/eventy/solutions/services/SolutionCategoryService.java
@@ -50,7 +50,7 @@ public class SolutionCategoryService {
 
     }
 
-    public CategoryWithIDDTO updateCategory(CategoryWithIDDTO newCategory) {
+    public Category updateCategory(CategoryWithIDDTO newCategory) {
         // check if exists
         Optional<Category> oldCategory = solutionCategoryRepository.findById(newCategory.getId());
         if (!oldCategory.isPresent()) {
@@ -64,7 +64,7 @@ public class SolutionCategoryService {
         category.setStatus(newCategory.getStatus());
 
         // save and return updated DTO
-        return new CategoryWithIDDTO(solutionCategoryRepository.save(category));
+        return solutionCategoryRepository.save(category);
     }
 
     public boolean deleteCategory(Long id) {
@@ -74,5 +74,33 @@ public class SolutionCategoryService {
         }
         solutionCategoryRepository.deleteById(id);
         return true;
+    }
+
+    public Category acceptCategory(Long id) {
+        Optional<Category> storedCategory = solutionCategoryRepository.findById(id);
+        if (storedCategory.isPresent()) {
+            Category acceptedCategory = storedCategory.get();
+            if (acceptedCategory.getStatus() != Status.PENDING) {
+                return null;
+            }
+            acceptedCategory.setStatus(Status.ACCEPTED);
+            return solutionCategoryRepository.save(acceptedCategory);
+        }
+        return null;
+    }
+
+    public Category changeCategory(CategoryWithIDDTO newCategory) {
+        Optional<Category> oldCategory = solutionCategoryRepository.findById(newCategory.getId());
+        if (oldCategory.isPresent()) {
+            Category category = oldCategory.get();
+            if (category.getStatus() != Status.PENDING) {
+                return null;
+            }
+            category.setName(newCategory.getName());
+            category.setDescription(newCategory.getDescription());
+            category.setStatus(Status.ACCEPTED);
+            return solutionCategoryRepository.save(category);
+        }
+        return null;
     }
 }

--- a/Eventy/src/main/java/org/example/eventy/solutions/services/SolutionService.java
+++ b/Eventy/src/main/java/org/example/eventy/solutions/services/SolutionService.java
@@ -1,5 +1,6 @@
 package org.example.eventy.solutions.services;
 
+import org.example.eventy.solutions.models.Category;
 import org.example.eventy.solutions.models.Solution;
 import org.example.eventy.solutions.repositories.SolutionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -69,5 +70,17 @@ public class SolutionService {
 
     public ArrayList<String> getAllUniqueCompaniesForSolutions() {
         return solutionRepository.findAllUniqueCompanyNamesForSolutions();
+    }
+
+    public boolean replaceCategoryForSolutionsWithOldCategory(Category oldCategory, Category newCategory) {
+        return solutionRepository.updateCategoryForAllSolutions(oldCategory, newCategory) == 1;
+    }
+
+    public Solution findSolutionWithPendingCategory(Category category) {
+        return solutionRepository.findByCategory(category).get(0);
+    }
+
+    public List<Solution> findAllByCategory(Category category) {
+        return solutionRepository.findByCategory(category);
     }
 }


### PR DESCRIPTION
Hello colleague!

In this PR I updated our backend for handling solution category requests. At first, I thought of doing everything through the general update function, but for easier usage, I also added 3 new functions for accepting, altering (and then accepting), and completely replacing a category request. I've also grabbed the provider IDs that need to be notified about said changes, which Tamara could use for notifications (the small part of code above each "notify" comment in the functions).

Let me know what you think!